### PR TITLE
51972 : Disable Challenges application by default

### DIFF
--- a/challenges-webapp/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
+++ b/challenges-webapp/src/main/webapp/WEB-INF/conf/challenges/app-center-configuration.xml
@@ -25,6 +25,10 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
             <type>org.exoplatform.appcenter.plugin.ApplicationPlugin</type>
             <init-params>
                 <value-param>
+                    <name>enabled</name>
+                    <value>${exo.app-center.challenges.enabled:false}</value>
+                </value-param>
+                <value-param>
                     <name>imagePath</name>
                     <value>war:/../images/challengesAppIcon.png</value>
                 </value-param>


### PR DESCRIPTION
Challenges application should be disabled by default and should not be displayed even in Application center administration
A new system property was added to enable/disable the application.

- **exo.app-center.challenges.enabled** : when set to false, the application won't be available in the applications menu nor in the app center administration. Default to false