### PR TITLE
TASK-53062 Upgrade to Hibernate 5.6

### DIFF
--- a/challenges-services/src/main/java/org/exoplatform/challenges/entity/AnnouncementEntity.java
+++ b/challenges-services/src/main/java/org/exoplatform/challenges/entity/AnnouncementEntity.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class AnnouncementEntity implements Serializable {
 
   @Id
-  @SequenceGenerator(name = "SEQ_ANNOUNCEMENT_ID", sequenceName = "SEQ_ANNOUNCEMENT_ID")
+  @SequenceGenerator(name = "SEQ_ANNOUNCEMENT_ID", sequenceName = "SEQ_ANNOUNCEMENT_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_ANNOUNCEMENT_ID")
   @Column(name = "ANNOUNCEMENT_ID", nullable = false)
   private Long            id;

--- a/challenges-services/src/main/java/org/exoplatform/challenges/entity/ChallengeEntity.java
+++ b/challenges-services/src/main/java/org/exoplatform/challenges/entity/ChallengeEntity.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class ChallengeEntity implements Serializable {
 
   @Id
-  @SequenceGenerator(name = "SEQ_CHALLENGE_ID", sequenceName = "SEQ_CHALLENGE_ID")
+  @SequenceGenerator(name = "SEQ_CHALLENGE_ID", sequenceName = "SEQ_CHALLENGE_ID", allocationSize = 1)
   @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_CHALLENGE_ID")
   @Column(name = "CHALLENGE_ID", nullable = false)
   private Long       id;

--- a/challenges-services/src/main/resources/db/changelog/challenge-rdbms.db.changelog-1.0.0.xml
+++ b/challenges-services/src/main/resources/db/changelog/challenge-rdbms.db.changelog-1.0.0.xml
@@ -114,4 +114,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-->
         <addAutoIncrement columnDataType="BIGINT"  columnName="ANNOUNCEMENT_ASSIGNEE_ID"  incrementBy="1" startWith="1" tableName="ANNOUNCEMENT_ASSIGNEE"/>
     </changeSet>
 
+    <changeSet author="challenge" id="1.0.0-6" dbms="hsqldb">
+        <createSequence sequenceName="SEQ_CHALLENGE_ID" startValue="1"/>
+        <createSequence sequenceName="SEQ_ANNOUNCEMENT_ID" startValue="1"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
To make the upgrade to Hibernate 5.6, this commit will:
1/ Delete definition of persistence.xml that is already made in gatein-portal. For each Persistence Unit, we have to define this file only once
2/ Generate Sequences for hsqldb which wasn't mandatory in previous versions of Hibernate and ensure to manage Sequence allocation size correctly switch Liquibase Configured incrementation (Default = 1)