### PR TITLE
Task-54431 : Improve code and fix upgrade errors

### DIFF
--- a/challenges-api/src/main/java/org/exoplatform/challenges/service/ChallengeService.java
+++ b/challenges-api/src/main/java/org/exoplatform/challenges/service/ChallengeService.java
@@ -69,7 +69,7 @@ public interface ChallengeService {
    * 
    * @return A {@link List<Challenge>} object
    */
-  List<Challenge> getAllChallenges() throws Exception;
+  List<Challenge> getAllChallenges();
 
   /**
    * delete challenge by id.

--- a/challenges-services/src/main/java/org/exoplatform/challenges/service/ChallengeServiceImpl.java
+++ b/challenges-services/src/main/java/org/exoplatform/challenges/service/ChallengeServiceImpl.java
@@ -45,7 +45,7 @@ public class ChallengeServiceImpl implements ChallengeService {
   }
 
   @Override
-  public List<Challenge> getAllChallenges() throws Exception {
+  public List<Challenge> getAllChallenges() {
     return challengeStorage.getAllChallenges();
   }
 

--- a/challenges-services/src/main/resources/conf/portal/configuration.xml
+++ b/challenges-services/src/main/resources/conf/portal/configuration.xml
@@ -78,7 +78,7 @@
           <property name="jobName" value="DataMigrationChallengeJob"/>
           <property name="groupName" value="Challenges"/>
           <property name="job" value="org.exoplatform.challenges.job.DataMigrationChallengeJob"/>
-          <property name="expression" value="${exo.challenge.DataMigrationChallenge.expression:0 0 0 * * ?}"/>
+          <property name="expression" value="${exo.challenge.DataMigrationChallenge.expression:0 0/30 * * * ?}"/>
         </properties-param>
       </init-params>
     </component-plugin>


### PR DESCRIPTION
The migration job runs once a day, which makes challenges unavailable for the application and the page is empty. In addition, if a challenge fails to upgrade, the job does not continue the upgrade of other challenges
This fix will :

- Change the migration job frequency to half an hour
- Make it possible to continue upgrading challenges when a challenge fails to be migrated.